### PR TITLE
fix: use ObjectCodec from JsonParser in custom deserializer

### DIFF
--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ChannelParametersDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ChannelParametersDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,8 +19,6 @@ import java.util.Map;
  * @author Pavel Bodiachevskii
  */
 public class ChannelParametersDeserializer extends JsonDeserializer<Map<String, Object>> {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public Map<String, Object> deserialize(
@@ -36,7 +33,7 @@ public class ChannelParametersDeserializer extends JsonDeserializer<Map<String, 
         node.fieldNames().forEachRemaining(
                 fieldName -> {
                     try {
-                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName)));
+                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName), objectCodec));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -46,12 +43,12 @@ public class ChannelParametersDeserializer extends JsonDeserializer<Map<String, 
         return parameters;
     }
 
-    private Object chooseKnownPojo(JsonNode parametersValue) throws IOException {
-        if (parametersValue.get("$ref") != null) {
-            return objectMapper.readValue(parametersValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode parametersValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = parametersValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(parametersValue.toString(), Parameter.class);
+            return parametersValue.traverse(objectCodec).readValueAs(Parameter.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsMessagesDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsMessagesDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,8 +19,6 @@ import java.util.Map;
  * @author Pavel Bodiachevskii
  */
 public class ComponentsMessagesDeserializer extends JsonDeserializer<Map<String, Object>> {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public Map<String, Object> deserialize(
@@ -36,7 +33,7 @@ public class ComponentsMessagesDeserializer extends JsonDeserializer<Map<String,
         node.fieldNames().forEachRemaining(
                 fieldName -> {
                     try {
-                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName)));
+                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName), objectCodec));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -46,12 +43,12 @@ public class ComponentsMessagesDeserializer extends JsonDeserializer<Map<String,
         return parameters;
     }
 
-    private Object chooseKnownPojo(JsonNode parametersValue) throws IOException {
-        if (parametersValue.get("$ref") != null) {
-            return objectMapper.readValue(parametersValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode parametersValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = parametersValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(parametersValue.toString(), Message.class);
+            return parametersValue.traverse(objectCodec).readValueAs(Message.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsParametersDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsParametersDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,8 +19,6 @@ import java.util.Map;
  * @author Pavel Bodiachevskii
  */
 public class ComponentsParametersDeserializer extends JsonDeserializer<Map<String, Object>> {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public Map<String, Object> deserialize(
@@ -36,7 +33,7 @@ public class ComponentsParametersDeserializer extends JsonDeserializer<Map<Strin
         node.fieldNames().forEachRemaining(
                 fieldName -> {
                     try {
-                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName)));
+                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName), objectCodec));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -46,12 +43,12 @@ public class ComponentsParametersDeserializer extends JsonDeserializer<Map<Strin
         return parameters;
     }
 
-    private Object chooseKnownPojo(JsonNode parametersValue) throws IOException {
-        if (parametersValue.get("$ref") != null) {
-            return objectMapper.readValue(parametersValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode parametersValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = parametersValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(parametersValue.toString(), Parameter.class);
+            return parametersValue.traverse(objectCodec).readValueAs(Parameter.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsSchemasDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/ComponentsSchemasDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,8 +19,6 @@ import java.util.Map;
  * @author Pavel Bodiachevskii
  */
 public class ComponentsSchemasDeserializer extends JsonDeserializer<Map<String, Object>> {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public Map<String, Object> deserialize(
@@ -36,7 +33,7 @@ public class ComponentsSchemasDeserializer extends JsonDeserializer<Map<String, 
         node.fieldNames().forEachRemaining(
                 fieldName -> {
                     try {
-                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName)));
+                        parameters.put(fieldName, chooseKnownPojo(node.get(fieldName), objectCodec));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -46,12 +43,12 @@ public class ComponentsSchemasDeserializer extends JsonDeserializer<Map<String, 
         return parameters;
     }
 
-    private Object chooseKnownPojo(JsonNode parametersValue) throws IOException {
-        if (parametersValue.get("$ref") != null) {
-            return objectMapper.readValue(parametersValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode parametersValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = parametersValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(parametersValue.toString(), Schema.class);
+            return parametersValue.traverse(objectCodec).readValueAs(Schema.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageCorrelationIdDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageCorrelationIdDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -19,22 +18,20 @@ import java.io.IOException;
  */
 public class MessageCorrelationIdDeserializer extends JsonDeserializer<Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
         JsonNode node = objectCodec.readTree(p);
 
-        return chooseKnownPojo(node);
+        return chooseKnownPojo(node, objectCodec);
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) throws IOException {
-        if (traitsValue.get("$ref") != null) {
-            return objectMapper.readValue(traitsValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = traitsValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(traitsValue.toString(), CorrelationId.class);
+            return traitsValue.traverse(objectCodec).readValueAs(CorrelationId.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageHeadersDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageHeadersDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -19,22 +18,20 @@ import java.io.IOException;
  */
 public class MessageHeadersDeserializer extends JsonDeserializer<Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
         JsonNode node = objectCodec.readTree(p);
 
-        return chooseKnownPojo(node);
+        return chooseKnownPojo(node, objectCodec);
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) throws IOException {
-        if (traitsValue.get("$ref") != null) {
-            return objectMapper.readValue(traitsValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = traitsValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(traitsValue.toString(), Schema.class);
+            return traitsValue.traverse(objectCodec).readValueAs(Schema.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessagePayloadDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessagePayloadDeserializer.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -18,22 +17,19 @@ import java.io.IOException;
  */
 public class MessagePayloadDeserializer extends JsonDeserializer<Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
         JsonNode node = objectCodec.readTree(p);
 
-        return chooseKnownPojo(node);
+        return chooseKnownPojo(node, objectCodec);
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) {
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) {
         try {
-            return objectMapper.readValue(traitsValue.toString(), Schema.class);
+            return traitsValue.traverse(objectCodec).readValueAs(Schema.class);
         } catch (Exception e) {
             return traitsValue;
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageTraitCorrelationIdDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/MessageTraitCorrelationIdDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -19,22 +18,20 @@ import java.io.IOException;
  */
 public class MessageTraitCorrelationIdDeserializer extends JsonDeserializer<Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
         JsonNode node = objectCodec.readTree(p);
 
-        return chooseKnownPojo(node);
+        return chooseKnownPojo(node, objectCodec);
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) throws IOException {
-        if (traitsValue.get("$ref") != null) {
-            return objectMapper.readValue(traitsValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = traitsValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(traitsValue.toString(), CorrelationId.class);
+            return traitsValue.traverse(objectCodec).readValueAs(CorrelationId.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/OperationMessageDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/OperationMessageDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -19,22 +18,20 @@ import java.io.IOException;
  */
 public class OperationMessageDeserializer extends JsonDeserializer<Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
         JsonNode node = objectCodec.readTree(p);
 
-        return chooseKnownPojo(node);
+        return chooseKnownPojo(node, objectCodec);
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) throws IOException {
-        if (traitsValue.get("$ref") != null) {
-            return objectMapper.readValue(traitsValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = traitsValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(traitsValue.toString(), Message.class);
+            return traitsValue.traverse(objectCodec).readValueAs(Message.class);
         }
     }
-
 }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/OperationTraitsDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/OperationTraitsDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,8 +20,6 @@ import java.util.List;
  */
 public class OperationTraitsDeserializer extends JsonDeserializer<List<Object>> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public List<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         ObjectCodec objectCodec = p.getCodec();
@@ -33,7 +30,7 @@ public class OperationTraitsDeserializer extends JsonDeserializer<List<Object>> 
         node.forEach(
                 traitsValue -> {
                     try {
-                        traits.add(chooseKnownPojo(traitsValue));
+                        traits.add(chooseKnownPojo(traitsValue, objectCodec));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -43,12 +40,12 @@ public class OperationTraitsDeserializer extends JsonDeserializer<List<Object>> 
         return traits;
     }
 
-    private Object chooseKnownPojo(JsonNode traitsValue) throws IOException {
-        if (traitsValue.get("$ref") != null) {
-            return objectMapper.readValue(traitsValue.toString(), Reference.class);
+    private Object chooseKnownPojo(JsonNode traitsValue, final ObjectCodec objectCodec) throws IOException {
+        JsonNode ref = traitsValue.get("$ref");
+        if (ref != null) {
+            return ref.traverse(objectCodec).readValueAs(Reference.class);
         } else {
-            return objectMapper.readValue(traitsValue.toString(), OperationTrait.class);
+            return traitsValue.traverse(objectCodec).readValueAs(OperationTrait.class);
         }
     }
-
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR fixes the issues #128 by reusing the ObjectCodec available from the JsonParser.

**Related issue(s)**
`Fixes #128`