### PR TITLE
fix: cannot load class, error in processing project classes - issue #65

### DIFF
--- a/asyncapi-plugin/asyncapi-plugin-maven/src/main/kotlin/com/asyncapi/plugin/maven/SchemaGeneratorMojo.kt
+++ b/asyncapi-plugin/asyncapi-plugin-maven/src/main/kotlin/com/asyncapi/plugin/maven/SchemaGeneratorMojo.kt
@@ -62,10 +62,10 @@ class SchemaGeneratorMojo: AbstractMojo() {
             }
 
             override fun resolveClassLoader(): ClassLoader {
-                val urls = emptySet<URL>()
+                val urls = mutableSetOf<URL>()
 
                 project.runtimeClasspathElements.forEach {
-                    urls.plus(File(it).toURI().toURL())
+                    urls.add(File(it).toURI().toURL())
                 }
 
                 return URLClassLoader(urls.toTypedArray(), Thread.currentThread().contextClassLoader)


### PR DESCRIPTION

**Description**

- fix for typo in processing project classes in SchemaGeneratorMojo.resolveClassLoader() method 
- because of the typo the maven project classes wasn't loaded

**Related issue(s)**
Resolves #65

**Test results**
![YamlSchemaGeneratorMojoTest](https://user-images.githubusercontent.com/25371075/221383732-e53b350c-ea5a-49d7-8961-b3a55ad2ecea.png)
![SchemaGeneratorMojoErrorsTest](https://user-images.githubusercontent.com/25371075/221383733-bffaaece-e87b-49e6-94d0-0c1086a8da27.png)
![JsonSchemaGeneratorMojoTest](https://user-images.githubusercontent.com/25371075/221383734-2b1af35d-76ab-4ac9-bb5b-69c39cb4e23d.png)
