### PR TITLE
fix: compile warnings

### DIFF
--- a/asyncapi-core/src/main/java/com/asyncapi/v2/_0_0/model/AsyncAPI.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/_0_0/model/AsyncAPI.java
@@ -43,6 +43,7 @@ public class AsyncAPI extends ExtendableObject {
      * and tooling should typically be compatible with the corresponding major.minor (1.0.*).
      * Patch versions will correspond to patches of this document.
      */
+    @Builder.Default
     @NotNull
     private String asyncapi = "2.0.0";
 

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/_6_0/model/AsyncAPI.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/_6_0/model/AsyncAPI.java
@@ -43,6 +43,7 @@ public class AsyncAPI extends ExtendableObject {
      * and tooling should typically be compatible with the corresponding major.minor (1.0.*).
      * Patch versions will correspond to patches of this document.
      */
+    @Builder.Default
     @NotNull
     private String asyncapi = "2.6.0";
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <lombok.version>1.18.26</lombok.version>
         <junit5.version>5.9.2</junit5.version>
         <dokka.version>1.7.0</dokka.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>


### PR DESCRIPTION
**Description**

- Fixed compile warning indicating the Maven Compiler Plugin was not specified
- Fixed compile warning indicating the source encoding was not specified
- Fixed Lombok compile warning indicating the `AsyncAPI` didn't had proper Builder defaults

**Related issue(s)**

None