### PR TITLE
fix: array schema is not being parsed correctly

### DIFF
--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/SchemaItemsDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/SchemaItemsDeserializer.java
@@ -6,9 +6,12 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SchemaItemsDeserializer extends JsonDeserializer<Object> {
 
@@ -20,11 +23,21 @@ public class SchemaItemsDeserializer extends JsonDeserializer<Object> {
         if (nodeType == JsonNodeType.OBJECT) {
             return readAsSchema(node, objectCodec);
         }
-        // TODO: Implement handling of scenario when items is an array of schemas. Maybe return a List<Schema>?
+        if (nodeType == JsonNodeType.ARRAY) {
+            return readAsListOfSchemas((ArrayNode) node, objectCodec);
+        }
         return readAsObject(node, objectCodec);
     }
 
-    private Object readAsSchema(JsonNode jsonNode, ObjectCodec objectCodec) throws IOException {
+    private List<Schema> readAsListOfSchemas(ArrayNode arrayNode, ObjectCodec objectCodec) throws IOException {
+        List<Schema> schemaList = new ArrayList<>();
+        for (JsonNode childNode : arrayNode) {
+            schemaList.add(readAsSchema(childNode, objectCodec));
+        }
+        return schemaList;
+    }
+
+    private Schema readAsSchema(JsonNode jsonNode, ObjectCodec objectCodec) throws IOException {
         try (JsonParser parser = jsonNode.traverse(objectCodec)) {
             return parser.readValueAs(Schema.class);
         }

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/SchemaItemsDeserializer.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/jackson/SchemaItemsDeserializer.java
@@ -1,0 +1,38 @@
+package com.asyncapi.v2.jackson;
+
+import com.asyncapi.v2.schema.Schema;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+
+import java.io.IOException;
+
+public class SchemaItemsDeserializer extends JsonDeserializer<Object> {
+
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        ObjectCodec objectCodec = jsonParser.getCodec();
+        JsonNode node = objectCodec.readTree(jsonParser);
+        JsonNodeType nodeType = node.getNodeType();
+        if (nodeType == JsonNodeType.OBJECT) {
+            return readAsSchema(node, objectCodec);
+        }
+        // TODO: Implement handling of scenario when items is an array of schemas. Maybe return a List<Schema>?
+        return readAsObject(node, objectCodec);
+    }
+
+    private Object readAsSchema(JsonNode jsonNode, ObjectCodec objectCodec) throws IOException {
+        try (JsonParser parser = jsonNode.traverse(objectCodec)) {
+            return parser.readValueAs(Schema.class);
+        }
+    }
+
+    private Object readAsObject(JsonNode jsonNode, ObjectCodec objectCodec) throws IOException {
+        try (JsonParser jsonParser = jsonNode.traverse(objectCodec)) {
+            return jsonParser.readValueAs(Object.class);
+        }
+    }
+}

--- a/asyncapi-core/src/main/java/com/asyncapi/v2/schema/Schema.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v2/schema/Schema.java
@@ -3,6 +3,7 @@ package com.asyncapi.v2.schema;
 import com.asyncapi.v2.ExtendableObject;
 import com.asyncapi.v2._0_0.jackson.model.schema.SchemasAdditionalPropertiesDeserializer;
 import com.asyncapi.v2._0_0.model.ExternalDocumentation;
+import com.asyncapi.v2.jackson.SchemaItemsDeserializer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
@@ -362,7 +363,7 @@ public class Schema extends ExtendableObject {
      * Omitting this keyword has the same behavior as an empty schema.
      */
     @Nullable
-    @JsonProperty
+    @JsonDeserialize(using = SchemaItemsDeserializer.class)
     public Object items;
 
     /**

--- a/asyncapi-core/src/test/kotlin/com/asyncapi/v2/_6_0/model/channel/message/MessageWithArrayPayloadTest.kt
+++ b/asyncapi-core/src/test/kotlin/com/asyncapi/v2/_6_0/model/channel/message/MessageWithArrayPayloadTest.kt
@@ -21,12 +21,10 @@ class MessageWithArrayPayloadTest {
     }
 
     @Test
-    @DisplayName("Test array items property is parsed as an array list")
-    fun testArrayItemsPropertyIsParsedAsArrayListWhenItIsAnArrayOfSchemas() {
+    @DisplayName("Test array items property is parsed as list of schemas")
+    fun testArrayItemsPropertyIsParsedAsArrayListOfSchemasWhenItIsAnArrayOfSchemas() {
         val model = ClasspathUtils.readAsString("/json/2.6.0/model/channel/message/messageWithArrayPayloadArrayOfSchemas.json")
         val schema = objectMapper.readValue(model, Message::class.java).payload as Schema
-        assertTrue(
-            schema.items is ArrayList<*>
-        )
+        assertTrue(schema.items is ArrayList<*> && (schema.items as ArrayList<*>).all { it is Schema })
     }
 }

--- a/asyncapi-core/src/test/kotlin/com/asyncapi/v2/_6_0/model/channel/message/MessageWithArrayPayloadTest.kt
+++ b/asyncapi-core/src/test/kotlin/com/asyncapi/v2/_6_0/model/channel/message/MessageWithArrayPayloadTest.kt
@@ -1,0 +1,32 @@
+package com.asyncapi.v2._6_0.model.channel.message
+
+import com.asyncapi.v2.ClasspathUtils
+import com.asyncapi.v2.schema.Schema
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class MessageWithArrayPayloadTest {
+    private val objectMapper = ObjectMapper()
+
+    @Test
+    @DisplayName("Test array items property is parsed as a schema object")
+    fun testArrayItemsPropertyIsParsedAsSchemaObjectWhenItIsASingleJsonSchema() {
+        val model = ClasspathUtils.readAsString("/json/2.6.0/model/channel/message/messageWithArrayPayloadJsonSchema.json")
+        val schema = objectMapper.readValue(model, Message::class.java).payload as Schema
+        assertTrue(
+            schema.items is Schema
+        )
+    }
+
+    @Test
+    @DisplayName("Test array items property is parsed as an array list")
+    fun testArrayItemsPropertyIsParsedAsArrayListWhenItIsAnArrayOfSchemas() {
+        val model = ClasspathUtils.readAsString("/json/2.6.0/model/channel/message/messageWithArrayPayloadArrayOfSchemas.json")
+        val schema = objectMapper.readValue(model, Message::class.java).payload as Schema
+        assertTrue(
+            schema.items is ArrayList<*>
+        )
+    }
+}

--- a/asyncapi-core/src/test/resources/json/2.6.0/model/channel/message/messageWithArrayPayloadArrayOfSchemas.json
+++ b/asyncapi-core/src/test/resources/json/2.6.0/model/channel/message/messageWithArrayPayloadArrayOfSchemas.json
@@ -1,0 +1,19 @@
+{
+  "bindings": {
+    "kafka": {
+      "key": {
+        "type": "string"
+      },
+      "bindingVersion": "0.4.0"
+    }
+  },
+  "payload": {
+    "type": "array",
+    "items": [
+      { "type": "number" },
+      { "type": "string" },
+      { "enum": ["Street", "Avenue", "Boulevard"] },
+      { "enum": ["NW", "NE", "SW", "SE"] }
+    ]
+  }
+}

--- a/asyncapi-core/src/test/resources/json/2.6.0/model/channel/message/messageWithArrayPayloadJsonSchema.json
+++ b/asyncapi-core/src/test/resources/json/2.6.0/model/channel/message/messageWithArrayPayloadJsonSchema.json
@@ -1,0 +1,32 @@
+{
+  "bindings": {
+    "kafka": {
+      "key": {
+        "type": "string"
+      },
+      "bindingVersion": "0.4.0"
+    }
+  },
+  "payload": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "done"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "done": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION

**Description**
Fixes array schema parsing with the following caveats:
- If 'items' is defined as an array of schemas, it will continue to be parsed as an Arraylist (like before).
Once we have some clarity on whether we should be using 'prefixIems', or returning a list of schemas, we can implement it.

In the meantime, with this fix, if 'items' is a json schema, then it will get parsed to a 'Schema' object, instead of the LinkedHashmap which we get right now.
We are a bit blocked due to this, and this fix will allow us to proceed with using this library in our project to validate messages with array schemas


**Related issue(s)**
#154 