### PR TITLE
fix: parse message payload of any type other than map of String to Object

### DIFF
--- a/.github/workflows/update-maintainers-trigger.yaml
+++ b/.github/workflows/update-maintainers-trigger.yaml
@@ -1,0 +1,28 @@
+# This action is centrally managed in https://github.com/asyncapi/.github/
+# Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+name: Trigger MAINTAINERS.yaml file update
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      # Check all valid CODEOWNERS locations: 
+      # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
+      - 'CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - '.docs/CODEOWNERS'
+
+jobs:
+  trigger-maintainers-update:
+    name: Trigger updating MAINTAINERS.yaml because of CODEOWNERS change
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # https://github.com/peter-evans/repository-dispatch/releases/tag/v3.0.0
+        with:
+          # The PAT with the 'public_repo' scope is required
+          token: ${{ secrets.GH_TOKEN }}
+          repository: ${{ github.repository_owner }}/community
+          event-type: trigger-maintainers-update

--- a/asyncapi-core/src/main/java/com/asyncapi/v3/_0_0/model/channel/message/MessageExample.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/v3/_0_0/model/channel/message/MessageExample.java
@@ -30,7 +30,7 @@ public class MessageExample extends ExtendableObject {
      * The value of this field MUST validate against the Message {@link Message} payload field.
      */
     @Nullable
-    public Map<String, Object> payload;
+    public Object payload;
 
     /**
      * A machine-friendly name.

--- a/asyncapi-core/src/test/kotlin/com/asyncapi/examples/v3/_0_0/ArrayAsMessageAsyncAPI.kt
+++ b/asyncapi-core/src/test/kotlin/com/asyncapi/examples/v3/_0_0/ArrayAsMessageAsyncAPI.kt
@@ -1,0 +1,100 @@
+package com.asyncapi.examples.v3._0_0
+
+import com.asyncapi.schemas.asyncapi.Reference
+import com.asyncapi.v3._0_0.model.channel.Channel
+import com.asyncapi.v3._0_0.model.channel.message.Message
+import com.asyncapi.v3._0_0.model.component.Components
+import com.asyncapi.v3._0_0.model.info.Info
+import com.asyncapi.v3._0_0.model.operation.Operation
+import com.asyncapi.v3._0_0.model.operation.OperationAction
+import com.asyncapi.schemas.asyncapi.AsyncAPISchema
+import com.asyncapi.v3._0_0.model.channel.message.MessageExample
+
+class ArrayAsMessageAsyncAPI: AbstractExampleValidationTest() {
+
+    override fun specificationLocation(): String = "/examples/v3.0.0/message-of-array-type-asyncapi.yml"
+
+    override fun expectedInfo(): Info {
+        return Info.builder()
+                .title("Message of array type example")
+                .version("1.0.0")
+                .build()
+    }
+
+    override fun expectedServers(): Map<String, Any> = emptyMap()
+
+    override fun expectedChannels(): Map<String, Any> {
+        return mapOf(
+                Pair("test",
+                        Channel.builder()
+                                .address("test")
+                                .messages(mapOf(
+                                        Pair("testMessages",
+                                            Reference("#/components/messages/testMessages")
+                                        )
+                                ))
+                                .build()
+                )
+        )
+    }
+
+    override fun expectedOperations(): Map<String, Any> {
+        return mapOf(
+                Pair("onTestMsg",
+                        Operation.builder()
+                                .action(OperationAction.RECEIVE)
+                                .channel(Reference("#/channels/test"))
+                                .messages(listOf(Reference("#/channels/test/messages/testMessages")))
+                                .build()
+                )
+        )
+    }
+
+    override fun expectedComponents(): Components {
+        return Components.builder()
+                .messages(mapOf(
+                        Pair("testMessages",
+                                Message.builder()
+                                        .payload(
+                                            Reference("#/components/schemas/objectWithKeyArray")
+                                        )
+                                        .examples(
+                                            listOf(
+                                                MessageExample.builder().name("example1").payload(
+                                                    listOf(
+                                                        mapOf("key" to "value1"),
+                                                        mapOf("key" to "value2")
+                                                    )
+                                                ).build(),
+                                                MessageExample.builder().name("example2").payload(
+                                                    listOf(
+                                                        mapOf("key" to "value3")
+                                                    )
+                                                ).build()
+                                            )
+                                        )
+                                        .build()
+                        )
+                ))
+                .schemas(mapOf(
+                    Pair(
+                        "objectWithKeyArray", AsyncAPISchema.builder()
+                            .type("array")
+                            .items(
+                                AsyncAPISchema.builder()
+                                    .type("object")
+                                    .properties(
+                                        mapOf(
+                                            Pair("key", AsyncAPISchema.builder().type("string").build())
+                                        )
+                                    )
+                                    .build()
+                            )
+                            .build()
+                    )
+                ))
+                .build()
+    }
+
+}
+

--- a/asyncapi-core/src/test/resources/examples/v3.0.0/message-of-array-type-asyncapi.yml
+++ b/asyncapi-core/src/test/resources/examples/v3.0.0/message-of-array-type-asyncapi.yml
@@ -1,0 +1,39 @@
+asyncapi: 3.0.0
+info:
+  title: Message of array type example
+  version: 1.0.0
+channels:
+  test:
+    address: test
+    messages:
+      testMessages:
+        $ref: '#/components/messages/testMessages'
+operations:
+  onTestMsg:
+    action: receive
+    channel:
+      $ref: '#/channels/test'
+    messages:
+      - $ref: '#/channels/test/messages/testMessages'
+components:
+  messages:
+    testMessages:
+      payload:
+        $ref: '#/components/schemas/objectWithKeyArray'
+      examples:
+        - name: example1
+          payload:
+            - key: "value1"
+            - key: "value2"
+        - name: example2
+          payload:
+            - key: "value3"
+  schemas:
+    objectWithKeyArray:
+      type: array
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+


### PR DESCRIPTION
Currently the asyncAPI parser expects the example payload to be an object and hence if it is an array, it does not parse the message associated with such array message.