### PR TITLE
fix(dependency): mark lombok as provided dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
+                <scope>provided</scope>
             </dependency>
             <!-- Json/Yaml -->
             <dependency>


### PR DESCRIPTION
Mark Lombok dependency as provided to avoid it's injection into final jar

Fixes #205 