### PR TITLE
feat: replace javax.validation with jakarta.validation

### DIFF
--- a/asyncapi-core/pom.xml
+++ b/asyncapi-core/pom.xml
@@ -48,9 +48,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/AMQPChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/AMQPChannelBinding.java
@@ -37,7 +37,7 @@ public class AMQPChannelBinding extends com.asyncapi.bindings.amqp.AMQPChannelBi
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "is", required = true, defaultValue = "routingKey")
     @JsonPropertyDescription("Defines what type of channel is it. Can be either queue or routingKey (default).")
     private AMQPChannelType is = AMQPChannelType.ROUTING_KEY;

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/exchange/AMQPChannelExchangeProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/exchange/AMQPChannelExchangeProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelExchangeProperties {
      * The name of the exchange. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Exchange name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/queue/AMQPChannelQueueProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/channel/queue/AMQPChannelQueueProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelQueueProperties {
      * The name of the queue. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Queue name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/operation/AMQPOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_1_0/operation/AMQPOperationBinding.java
@@ -37,7 +37,7 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "TTL (Time-To-Live) for the message must be greater than or equal to zero"
     )
@@ -81,11 +81,11 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/AMQPChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/AMQPChannelBinding.java
@@ -37,7 +37,7 @@ public class AMQPChannelBinding extends com.asyncapi.bindings.amqp.AMQPChannelBi
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "is", required = true, defaultValue = "routingKey")
     @JsonPropertyDescription("Defines what type of channel is it. Can be either queue or routingKey (default).")
     private AMQPChannelType is = AMQPChannelType.ROUTING_KEY;

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/exchange/AMQPChannelExchangeProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/exchange/AMQPChannelExchangeProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelExchangeProperties {
      * The name of the exchange. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Exchange name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/queue/AMQPChannelQueueProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/channel/queue/AMQPChannelQueueProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelQueueProperties {
      * The name of the queue. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Queue name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/operation/AMQPOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_2_0/operation/AMQPOperationBinding.java
@@ -37,7 +37,7 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "TTL (Time-To-Live) for the message must be greater than or equal to zero"
     )
@@ -81,11 +81,11 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/AMQPChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/AMQPChannelBinding.java
@@ -37,7 +37,7 @@ public class AMQPChannelBinding extends com.asyncapi.bindings.amqp.AMQPChannelBi
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "is", required = true, defaultValue = "routingKey")
     @JsonPropertyDescription("Defines what type of channel is it. Can be either queue or routingKey (default).")
     private AMQPChannelType is = AMQPChannelType.ROUTING_KEY;

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/exchange/AMQPChannelExchangeProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/exchange/AMQPChannelExchangeProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelExchangeProperties {
      * The name of the exchange. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Exchange name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/queue/AMQPChannelQueueProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/channel/queue/AMQPChannelQueueProperties.java
@@ -33,7 +33,7 @@ public class AMQPChannelQueueProperties {
      * The name of the queue. It MUST NOT exceed 255 characters long.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Queue name must not exceed 255 characters long."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/operation/AMQPOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/amqp/v0/_3_0/operation/AMQPOperationBinding.java
@@ -37,7 +37,7 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "TTL (Time-To-Live) for the message must be greater than or equal to zero"
     )
@@ -81,11 +81,11 @@ public class AMQPOperationBinding extends com.asyncapi.bindings.amqp.AMQPOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "Delivery mode of the message must be either 1 (transient) or 2 (persistent)"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/channel/GooglePubSubChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/channel/GooglePubSubChannelBinding.java
@@ -37,7 +37,7 @@ public class GooglePubSubChannelBinding extends com.asyncapi.bindings.googlepubs
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "topic", required = true)
     @JsonPropertyDescription("The Google Cloud Pub/Sub Topic name.")
     private String topic = "";
@@ -71,7 +71,7 @@ public class GooglePubSubChannelBinding extends com.asyncapi.bindings.googlepubs
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "schemaSettings", required = true)
     @JsonPropertyDescription("Settings for validating messages published against a schema")
     private GooglePubSubChannelSchemaSettings schemaSettings = new GooglePubSubChannelSchemaSettings();

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/channel/GooglePubSubChannelSchemaSettings.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/channel/GooglePubSubChannelSchemaSettings.java
@@ -34,7 +34,7 @@ public class GooglePubSubChannelSchemaSettings {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "encoding", required = true)
     @JsonPropertyDescription("The encoding of the message (Must be one of the possible https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics#encoding values.)")
     private String encoding = "";
@@ -60,7 +60,7 @@ public class GooglePubSubChannelSchemaSettings {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "name", required = true)
     @JsonPropertyDescription("The name of the schema that messages published should be validated against (The format is projects/{project}/schemas/{schema}.)")
     private String name = "";

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/message/GooglePubSubMessageSchemaDefinition.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_1_0/message/GooglePubSubMessageSchemaDefinition.java
@@ -37,7 +37,7 @@ public class GooglePubSubMessageSchemaDefinition {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "name", required = true)
     @JsonPropertyDescription("The name of the schema")
     private String name = "";
@@ -47,7 +47,7 @@ public class GooglePubSubMessageSchemaDefinition {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "type", required = true)
     @JsonPropertyDescription("The type of the schema")
     private GooglePubSubMessageSchemaDefinitionType type = GooglePubSubMessageSchemaDefinitionType.PROTOBUF;

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/channel/GooglePubSubChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/channel/GooglePubSubChannelBinding.java
@@ -61,7 +61,7 @@ public class GooglePubSubChannelBinding extends com.asyncapi.bindings.googlepubs
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "schemaSettings", required = true)
     @JsonPropertyDescription("Settings for validating messages published against a schema")
     private GooglePubSubChannelSchemaSettings schemaSettings = new GooglePubSubChannelSchemaSettings();

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/channel/GooglePubSubChannelSchemaSettings.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/channel/GooglePubSubChannelSchemaSettings.java
@@ -34,7 +34,7 @@ public class GooglePubSubChannelSchemaSettings {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "encoding", required = true)
     @JsonPropertyDescription("The encoding of the message (Must be one of the possible https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics#encoding values.)")
     private String encoding = "";
@@ -60,7 +60,7 @@ public class GooglePubSubChannelSchemaSettings {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "name", required = true)
     @JsonPropertyDescription("The name of the schema that messages published should be validated against (The format is projects/{project}/schemas/{schema}.)")
     private String name = "";

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/message/GooglePubSubMessageSchemaDefinition.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/googlepubsub/v0/_2_0/message/GooglePubSubMessageSchemaDefinition.java
@@ -37,7 +37,7 @@ public class GooglePubSubMessageSchemaDefinition {
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "name", required = true)
     @JsonPropertyDescription("The name of the schema")
     private String name = "";

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/http/v0/_1_0/operation/HTTPOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/http/v0/_1_0/operation/HTTPOperationBinding.java
@@ -36,7 +36,7 @@ public class HTTPOperationBinding extends com.asyncapi.bindings.http.HTTPOperati
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "type", required = true)
     @JsonPropertyDescription("Type of operation. Its value MUST be either request or response.")
     private HTTPOperationType type = HTTPOperationType.REQUEST;

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelBinding.java
@@ -70,11 +70,11 @@ public class IBMMQChannelBinding extends com.asyncapi.bindings.ibmmq.IBMMQChanne
      * MUST be 0-104,857,600 bytes (100 MB).
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "Maximum length of the physical message (in bytes) must be greater or equals to 0"
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 104857600,
             message = "Maximum length of the physical message (in bytes) must be lower or equals to 104857600"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelQueueProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelQueueProperties.java
@@ -34,8 +34,8 @@ public class IBMMQChannelQueueProperties {
      * A value MUST be specified. MUST NOT exceed 48 characters in length. MUST be a valid IBM MQ queue name
      */
     @NotNull
-    @javax.validation.constraints.NotNull
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.NotNull
+    @jakarta.validation.constraints.Size(
             max = 48,
             message = "Name of the IBM MQ queue must be less or equals to 48"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelTopicProperties.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/channel/IBMMQChannelTopicProperties.java
@@ -34,7 +34,7 @@ public class IBMMQChannelTopicProperties {
      * MUST NOT exceed 10240 characters in length. MAY coexist with topic.objectName
      */
     @Nullable
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 10240,
             message = "Maximum length of topic string must be lower or equals to 10240"
     )
@@ -51,7 +51,7 @@ public class IBMMQChannelTopicProperties {
      * MUST NOT exceed 48 characters in length. MAY coexist with topic.string
      */
     @Nullable
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 48,
             message = "Maximum length of topic name must be lower or equals to 48"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/message/IBMMQMessageBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/message/IBMMQMessageBinding.java
@@ -74,7 +74,7 @@ public class IBMMQMessageBinding extends com.asyncapi.bindings.ibmmq.IBMMQMessag
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "Expiry must be greater or equals to 0"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/server/IBMMQServerBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/ibmmq/v0/_1_0/server/IBMMQServerBinding.java
@@ -84,11 +84,11 @@ public class IBMMQServerBinding extends com.asyncapi.bindings.ibmmq.IBMMQServerB
      * MUST be 0-999999
      */
     @Builder.Default
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "Heart beat interval must be greater or equals to 0"
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 999999,
             message = "Heart beat interval must be less or equals to 999999"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_3_0/channel/KafkaChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_3_0/channel/KafkaChannelBinding.java
@@ -41,7 +41,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of partitions must be greater or equals to 1"
     )
@@ -55,7 +55,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of replicas must be greater or equals to 1"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_4_0/channel/KafkaChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_4_0/channel/KafkaChannelBinding.java
@@ -39,7 +39,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of partitions must be greater or equals to 1"
     )
@@ -53,7 +53,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of replicas must be greater or equals to 1"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_4_0/channel/KafkaChannelTopicConfiguration.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_4_0/channel/KafkaChannelTopicConfiguration.java
@@ -36,7 +36,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_retention.ms">retention.ms</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = -1,
             message = "retention.ms must be greater or equals to -1"
     )
@@ -48,7 +48,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_retention.bytes">retention.bytes</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = -1,
             message = "retention.bytes must be greater or equals to -1"
     )
@@ -60,7 +60,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms">delete.retention.ms</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "delete.retention.ms must be greater or equals to 0"
     )
@@ -72,7 +72,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes">max.message.bytes</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "max.message.bytes must be greater or equals to 0"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_5_0/channel/KafkaChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_5_0/channel/KafkaChannelBinding.java
@@ -41,7 +41,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of partitions must be greater or equals to 1"
     )
@@ -55,7 +55,7 @@ public class KafkaChannelBinding extends com.asyncapi.bindings.kafka.KafkaChanne
      * MUST be positive.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 1,
             message = "Number of replicas must be greater or equals to 1"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_5_0/channel/KafkaChannelTopicConfiguration.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/kafka/v0/_5_0/channel/KafkaChannelTopicConfiguration.java
@@ -38,7 +38,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_retention.ms">retention.ms</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = -1,
             message = "retention.ms must be greater or equals to -1"
     )
@@ -50,7 +50,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_retention.bytes">retention.bytes</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = -1,
             message = "retention.bytes must be greater or equals to -1"
     )
@@ -62,7 +62,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms">delete.retention.ms</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "delete.retention.ms must be greater or equals to 0"
     )
@@ -74,7 +74,7 @@ public class KafkaChannelTopicConfiguration {
      * The <a href="https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes">max.message.bytes</a> configuration option.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "max.message.bytes must be greater or equals to 0"
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_1_0/operation/MQTTOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_1_0/operation/MQTTOperationBinding.java
@@ -36,11 +36,11 @@ public class MQTTOperationBinding extends com.asyncapi.bindings.mqtt.MQTTOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "QoS must be greater or equals to 0."
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "QoS must be lower or equals to 0."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_1_0/server/MQTTServerLastWillConfiguration.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_1_0/server/MQTTServerLastWillConfiguration.java
@@ -36,11 +36,11 @@ public class MQTTServerLastWillConfiguration {
      * Its value MUST be either 0, 1 or 2.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "QoS must be greater or equals to 0."
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "QoS must be lower or equals to 0."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_2_0/operation/MQTTOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_2_0/operation/MQTTOperationBinding.java
@@ -38,11 +38,11 @@ public class MQTTOperationBinding extends com.asyncapi.bindings.mqtt.MQTTOperati
      * Applies to: publish, subscribe
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "QoS must be greater or equals to 0."
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "QoS must be lower or equals to 2."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_2_0/server/MQTTServerLastWillConfiguration.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/mqtt/v0/_2_0/server/MQTTServerLastWillConfiguration.java
@@ -36,11 +36,11 @@ public class MQTTServerLastWillConfiguration {
      * Its value MUST be either 0, 1 or 2.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "QoS must be greater or equals to 0."
     )
-    @javax.validation.constraints.Max(
+    @jakarta.validation.constraints.Max(
             value = 2,
             message = "QoS must be lower or equals to 0."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/nats/v0/_1_0/operation/NATSOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/nats/v0/_1_0/operation/NATSOperationBinding.java
@@ -31,7 +31,7 @@ public class NATSOperationBinding extends com.asyncapi.bindings.nats.NATSOperati
      * Defines the name of the queue to use. It MUST NOT exceed 255 characters.
      */
     @Nullable
-    @javax.validation.constraints.Size(
+    @jakarta.validation.constraints.Size(
             max = 255,
             message = "Queue name must be lower or equals to 255."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/pulsar/v0/_1_0/channel/PulsarChannelBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/pulsar/v0/_1_0/channel/PulsarChannelBinding.java
@@ -35,7 +35,7 @@ public class PulsarChannelBinding extends com.asyncapi.bindings.pulsar.PulsarCha
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty("namespace")
     @JsonPropertyDescription("The namespace the channel is associated with.")
     private String namespace = "";
@@ -45,7 +45,7 @@ public class PulsarChannelBinding extends com.asyncapi.bindings.pulsar.PulsarCha
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.NotNull
+    @jakarta.validation.constraints.NotNull
     @JsonProperty(value = "persistence", defaultValue = "persistent")
     @JsonPropertyDescription("Persistence of the topic in Pulsar. It MUST be either persistent or non-persistent.")
     private PulsarChannelPersistence persistence = PulsarChannelPersistence.PERSISTENT;
@@ -54,7 +54,7 @@ public class PulsarChannelBinding extends com.asyncapi.bindings.pulsar.PulsarCha
      * Topic compaction threshold given in Megabytes.
      */
     @Nullable
-    @javax.validation.constraints.Min(
+    @jakarta.validation.constraints.Min(
             value = 0,
             message = "Topic compaction threshold must be greater or equals to 0."
     )

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/sns/v0/_1_0/operation/SNSOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/sns/v0/_1_0/operation/SNSOperationBinding.java
@@ -39,7 +39,7 @@ public class SNSOperationBinding extends com.asyncapi.bindings.sns.SNSOperationB
      */
     @NotNull
     @Builder.Default
-    @javax.validation.constraints.Size(min = 1)
+    @jakarta.validation.constraints.Size(min = 1)
     private List<@NotNull SNSOperationConsumer> consumers = Collections.emptyList();
 
     /**

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/solace/v0/_4_0/operation/SolaceOperationBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/solace/v0/_4_0/operation/SolaceOperationBinding.java
@@ -49,8 +49,8 @@ public class SolaceOperationBinding extends com.asyncapi.bindings.solace.SolaceO
      * a Schema Object containing the definition of the priority.
      */
     @Nullable
-    @javax.validation.constraints.Min(0)
-    @javax.validation.constraints.Max(255)
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(255)
     private Integer priority;
 
     /**

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/solace/v0/_4_0/server/SolaceServerBinding.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/solace/v0/_4_0/server/SolaceServerBinding.java
@@ -42,7 +42,7 @@ public class SolaceServerBinding extends com.asyncapi.bindings.solace.SolaceServ
      */
     @Nullable
     @JsonProperty("clientName")
-    @javax.validation.constraints.Size(min = 1, max = 160)
+    @jakarta.validation.constraints.Size(min = 1, max = 160)
     private String clientName;
 
     @Override

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/sqs/v0/_2_0/channel/SQSChannelQueue.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/sqs/v0/_2_0/channel/SQSChannelQueue.java
@@ -62,8 +62,8 @@ public class SQSChannelQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(0)
-    @javax.validation.constraints.Max(15)
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(15)
     private Integer deliveryDelay = 0;
 
     /**
@@ -71,8 +71,8 @@ public class SQSChannelQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(0)
-    @javax.validation.constraints.Max(43200)
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(43200)
     private Integer visibilityTimeout = 30;
 
     /**
@@ -91,8 +91,8 @@ public class SQSChannelQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(60)
-    @javax.validation.constraints.Max(1209600)
+    @jakarta.validation.constraints.Min(60)
+    @jakarta.validation.constraints.Max(1209600)
     private Integer messageRetentionPeriod = 345600;
 
     /**

--- a/asyncapi-core/src/main/java/com/asyncapi/bindings/sqs/v0/_2_0/operation/SQSOperationQueue.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/bindings/sqs/v0/_2_0/operation/SQSOperationQueue.java
@@ -75,8 +75,8 @@ public class SQSOperationQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(0)
-    @javax.validation.constraints.Max(15)
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(15)
     private Integer deliveryDelay = 0;
 
     /**
@@ -84,8 +84,8 @@ public class SQSOperationQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(0)
-    @javax.validation.constraints.Max(43200)
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(43200)
     private Integer visibilityTimeout = 30;
 
     /**
@@ -104,8 +104,8 @@ public class SQSOperationQueue {
      */
     @Nullable
     @Builder.Default
-    @javax.validation.constraints.Min(60)
-    @javax.validation.constraints.Max(1209600)
+    @jakarta.validation.constraints.Min(60)
+    @jakarta.validation.constraints.Max(1209600)
     private Integer messageRetentionPeriod = 345600;
 
     /**

--- a/asyncapi-core/src/main/java/com/asyncapi/schemas/asyncapi/AsyncAPISchema.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/schemas/asyncapi/AsyncAPISchema.java
@@ -15,7 +15,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;

--- a/asyncapi-core/src/main/java/com/asyncapi/schemas/json/JsonSchema.java
+++ b/asyncapi-core/src/main/java/com/asyncapi/schemas/json/JsonSchema.java
@@ -12,7 +12,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
`javax.validation` has been replaced with `jakarta.validation`

Fixes https://github.com/asyncapi/jasyncapi/issues/206